### PR TITLE
Update app1.py

### DIFF
--- a/app1.py
+++ b/app1.py
@@ -46,7 +46,12 @@ def fetch_gas_data(w3: Web3, block_tag="latest"):
 def fetch_tx_data(w3: Web3, tx_hash: str):
     rcpt = w3.eth.get_transaction_receipt(tx_hash)
     tx = w3.eth.get_transaction(tx_hash)
-    fee = Web3.from_wei(rcpt.gasUsed * tx.get("maxFeePerGas", tx.gasPrice), "ether")
+    
+    # Prefer actual paid price (EIP-1559); fallback to legacy gasPrice
+eff_price = getattr(rcpt, "effectiveGasPrice", None)
+gas_price_wei = eff_price if eff_price is not None else (tx.get("gasPrice", 0) or 0)
+fee = Web3.from_wei(rcpt.gasUsed * gas_price_wei, "ether")
+
     return {
         "from": tx["from"],
         "to": tx["to"],


### PR DESCRIPTION
added a use effectiveGasPrice from the receipt to compute the actual fee paid, with a safe fallback to legacy gasPrice. This avoids over/under-reporting fees for EIP-1559 transactions.