### PR TITLE
Update provider_consistency.py

### DIFF
--- a/provider_consistency.py
+++ b/provider_consistency.py
@@ -63,7 +63,7 @@ def compare_dicts(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, bool]:
     return {k: (a.get(k) == b.get(k)) for k in sorted(set(a.keys()) | set(b.keys()))}
 
 def fetch_tx_bundle(w3: Web3, tx_hash: str) -> Dict[str, Any]:
-    rcpt = w3.eth.get_transaction_receipt(tx_hash)
+    rcpt = safe_call(w3.eth.get_transaction_receipt, tx_hash)
     if rcpt is None or rcpt.blockNumber is None:
         return {"statusText": "pending_or_not_found"}
     chain_id = w3.eth.chain_id
@@ -78,7 +78,7 @@ def fetch_tx_bundle(w3: Web3, tx_hash: str) -> Dict[str, Any]:
     }
 
 def fetch_block_bundle(w3: Web3, block_id) -> Dict[str, Any]:
-    header = w3.eth.get_block(block_id)
+    header = safe_call(w3.eth.get_block, block_id)
     chain_id = w3.eth.chain_id
     return {
         "chainId": int(chain_id),


### PR DESCRIPTION
Suggest to add automatic retry logic if an RPC call fails once (for example, due to temporary timeout or rate limiting). This improves reliability without changing program behavior.