### PR TITLE
Shows the total number of fields compared between providers

### DIFF
--- a/provider_consistency.py
+++ b/provider_consistency.py
@@ -143,6 +143,7 @@ def main():
         print("\n— Comparison —")
         for k in ["chainId", "blockNumber", "status", "gasUsed", "commitment"]:
             print(f"{k:12s}: {'✅' if cmp[k] else '❌'}")
+            print(f"🧮 Fields compared: {len(cmp.keys())}")
         if all(cmp.values()):
             print("🔒 Soundness confirmed for tx across providers.")
         else:


### PR DESCRIPTION
Quickly shows how many parameters were validated.
Useful for debugging or expanding the comparison logic later. Just one clean line, no logic changes, and improves output clarity.