### PR TITLE
Update fee-profile.py

### DIFF
--- a/fee-profile.py
+++ b/fee-profile.py
@@ -158,6 +158,7 @@ def main():
     ep = result["effectivePriceGwei"]
     tp = result["tipGweiApprox"]
     print(f"🕒 Average Block Time: {result['avgBlockTimeSec']} seconds")
+    print(f"🎯 Gas target ratio: {(block.gasUsed / (block.gasLimit / 2)) * 100:.1f}% of target")
     print(f"⛽ Base Fee (Gwei):   p50={bf['p50']}  p95={bf['p95']}  min={bf['min']}  max={bf['max']}")
     print(f"💵 Effective Price:   p50={ep['p50']}  p95={ep['p95']}  min={ep['min']}  max={ep['max']}  (n={ep['count']})")
     print(f"🎁 Priority Tip ~:    p50={tp['p50']}  p95={tp['p95']}  min={tp['min']}  max={tp['max']}  (n={tp['count']})")


### PR DESCRIPTION
161 - shows how full the block is relative to Ethereum’s target gas usage (half of the gas limit) A value near 100 % means strong network demand; under 50 % means fees are likely falling