### PR TITLE
Update rpc_latency_monitor.py

### DIFF
--- a/rpc_latency_monitor.py
+++ b/rpc_latency_monitor.py
@@ -7,6 +7,8 @@ def check_endpoint(rpc_url, threshold_ms=200):
         return rpc_url, None, None, "DISCONNECTED"
     t0 = time.time()
     block = w3.eth.block_number
+    if 'last_block' in locals() and block == last_block: print(f"⚠️  {rpc_url} hasn’t advanced since last check (block {block})")
+    last_block = block
     latency_ms = (time.time() - t0) * 1000
     status = "OK" if latency_ms <= threshold_ms else "SLOW"
     return rpc_url, block, round(latency_ms), status


### PR DESCRIPTION
10 - it warns the user if two consecutive RPC checks return the same block number, which can mean the node isn’t updating