### PR TITLE
Docstring for read_hashes

### DIFF
--- a/batch_fee_report.py
+++ b/batch_fee_report.py
@@ -34,7 +34,12 @@ def is_tx_hash(s: str) -> bool:
     return isinstance(s, str) and s.startswith("0x") and len(s) == 66
 
 def read_hashes(source_file: str | None, limit: int | None) -> List[str]:
+    """
+    Read transaction hashes from a file or stdin, filter invalid ones,
+    and respect the optional limit.
+    """
     lines: Iterable[str]
+
     if source_file:
         with open(source_file, "r", encoding="utf-8") as f:
             lines = f.readlines()


### PR DESCRIPTION
Clarifies that it accepts stdin or a file and respects --limit.