### PR TITLE
Docstring for to_csv

### DIFF
--- a/batch_fee_report.py
+++ b/batch_fee_report.py
@@ -131,6 +131,12 @@ def summarize_tx(w3: Web3, tx_hash: str, block_cache: Dict[int, Any], latest_blo
     }
 
 def to_csv(rows: List[Dict[str, Any]], out_path: str | None):
+    """
+    Write transaction summaries to CSV.
+
+    If out_path is None, writes to stdout; otherwise writes to the given file
+    and logs the path to stderr.
+    """
     if not rows:
         print("⚠️  No rows to write.", file=sys.stderr)
         return


### PR DESCRIPTION
Clarifies that empty rows are not written and that logs go to stderr.