### PR TITLE
Early warning if chain IDs differ (non-JSON tx mode)

### DIFF
--- a/provider_consistency.py
+++ b/provider_consistency.py
@@ -131,6 +131,12 @@ def main():
             sys.exit(0)
 
         cmp = compare_dicts(a, b)
+                if a.get("chainId") != b.get("chainId") and not args.json:
+            print(
+                f"⚠️  Providers report different chain IDs: {a.get('chainId')} vs {b.get('chainId')}.",
+                file=sys.stderr,
+            )
+
         if args.json:
             import json
             print(json.dumps({"primary": a, "secondary": b, "match": cmp}, indent=2, sort_keys=True))


### PR DESCRIPTION
If providers point to different chains, comparisons are meaningless; warn clearly.