### PR TITLE
Fix disconnected endpoint logging

### DIFF
--- a/rpc_latency_monitor.py
+++ b/rpc_latency_monitor.py
@@ -2,9 +2,9 @@ import time, csv, argparse, sys
 from web3 import Web3
 
 def check_endpoint(rpc_url, threshold_ms=200):
-    w3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout":10}))
+    w3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout": 10}))
     if not w3.is_connected():
-        print(f"🌐 {rpc_url} → chainId: {w3.eth.chain_id}")
+        print(f"❌ {rpc_url} is DISCONNECTED")
         return rpc_url, None, None, "DISCONNECTED"
     t0 = time.time()
     block = w3.eth.block_number


### PR DESCRIPTION
When w3.is_connected() is False, accessing w3.eth.chain_id will likely fail. Just log “DISCONNECTED” cleanly.