### PR TITLE
Use time.monotonic() for latency measurement

### DIFF
--- a/rpc_latency_monitor.py
+++ b/rpc_latency_monitor.py
@@ -6,8 +6,9 @@ def check_endpoint(rpc_url, threshold_ms=200):
     if not w3.is_connected():
         print(f"🌐 {rpc_url} → chainId: {w3.eth.chain_id}")
         return rpc_url, None, None, "DISCONNECTED"
-    t0 = time.time()
+      t0 = time.monotonic()
     block = w3.eth.block_number
+    latency_ms = (time.monotonic() - t0) * 1000
     if 'last_block' in locals() and block == last_block: print(f"⚠️  {rpc_url} hasn’t advanced since last check (block {block})")
     last_block = block
     latency_ms = (time.time() - t0) * 1000


### PR DESCRIPTION
monotonic() is better for measuring short durations than time.time().