### PR TITLE
Added --timeout for RPC HTTP calls

### DIFF
--- a/rpc_latency_monitor.py
+++ b/rpc_latency_monitor.py
@@ -1,13 +1,13 @@
 import time, csv, argparse, sys
 from web3 import Web3
 
-def check_endpoint(rpc_url, threshold_ms=200):
-    w3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout":10}))
+def check_endpoint(rpc_url: str, threshold_ms: int = 200, timeout: float = 10.0):
+     w3 = Web3(Web3.HTTPProvider(rpc_url, request_kwargs={"timeout": timeout}))
     if not w3.is_connected():
         print(f"🌐 {rpc_url} → chainId: {w3.eth.chain_id}")
         return rpc_url, None, None, "DISCONNECTED"
     t0 = time.time()
-    block = w3.eth.block_number
+    block = w3.eth.block_numbermain()
     if 'last_block' in locals() and block == last_block: print(f"⚠️  {rpc_url} hasn’t advanced since last check (block {block})")
     last_block = block
     latency_ms = (time.time() - t0) * 1000
@@ -17,6 +17,8 @@ def check_endpoint(rpc_url, threshold_ms=200):
     return rpc_url, block, round(latency_ms), status
 
 def main():
+        parser.add_argument("--timeout", type=float, default=10.0, help="RPC HTTP timeout in seconds")
+
     parser = argparse.ArgumentParser(description="RPC latency monitor")
     parser.add_argument("--rpcs", nargs="+", required=True, help="List of RPC URLs")
     parser.add_argument("--threshold", type=int, default=200, help="Latency threshold in ms")
@@ -25,9 +27,12 @@ def main():
 
     # Run once (could be looped or scheduled)
     results = []
-    for url in args.rpcs:
+      for url in args.rpcs:
         url, block, latency, status = check_endpoint(url, args.threshold)
+
         results.append((time.strftime("%Y-%m-%d %H:%M:%S"), url, block, latency, status))
+              for url in args.rpcs:
+        url, block, latency, status = check_endpoint(url, args.threshold, args.timeout)
 
     with open(args.output, "a", newline="") as f:
         writer = csv.writer(f)


### PR DESCRIPTION
Allows tuning the HTTP timeout instead of hard-coding 10 seconds.