### PR TITLE
Added --max-latency-exit to fail if any endpoint is too slow

### DIFF
--- a/rpc_latency_monitor.py
+++ b/rpc_latency_monitor.py
@@ -21,6 +21,11 @@ def main():
     parser.add_argument("--rpcs", nargs="+", required=True, help="List of RPC URLs")
     parser.add_argument("--threshold", type=int, default=200, help="Latency threshold in ms")
     parser.add_argument("--output", default="rpc_latency_log.csv", help="Output log file path")
+        parser.add_argument(
+        "--max-latency-exit",
+        type=int,
+        help="If set, exit with code 1 if any endpoint latency (ms) exceeds this value",
+    )
     args = parser.parse_args()
 
     # Run once (could be looped or scheduled)
@@ -28,6 +33,22 @@ def main():
     for url in args.rpcs:
         url, block, latency, status = check_endpoint(url, args.threshold)
         results.append((time.strftime("%Y-%m-%d %H:%M:%S"), url, block, latency, status))
+    if args.max_latency_exit is not None:
+        too_slow = any(
+            latency is not None and latency > args.max_latency_exit
+            for _, _, _, latency, _ in results
+        )
+        if too_slow:
+            print(
+                f"⚠️  At least one endpoint exceeded max latency of {args.max_latency_exit} ms",
+                file=sys.stderr,
+            )
+            # still write CSV, but remember to exit with 1 at the very end
+            exit_code = 1
+        else:
+            exit_code = 0
+    else:
+        exit_code = 0
 
     with open(args.output, "a", newline="") as f:
         writer = csv.writer(f)
@@ -38,3 +59,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    sys.exit(exit_code)


### PR DESCRIPTION
Useful for CI/monitoring: exit non-zero if any endpoint exceeds a max.