### PR TITLE
fix datetime import and timestamp print inside main()

### DIFF
--- a/App2.py
+++ b/App2.py
@@ -139,10 +139,12 @@ def colorize(text, color):
     return text  # простой безопасный вариант без цветов
 
 def main():
+    from datetime import datetime
+
     args = parse_args()
-from datetime import datetime
-print(f"🕒 Timestamp: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
+    print(f"🕒 Timestamp: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC")
     if not is_tx_hash(args.tx_hash):
+
         print("❌ Invalid transaction hash format.")
         sys.exit(1)
 


### PR DESCRIPTION
Right now from datetime import datetime and the timestamp print are outside main() and break indentation. This PR moves them inside main()