### PR TITLE
Fix tx_type_label indentation and docstring

### DIFF
--- a/batch_fee_report.py
+++ b/batch_fee_report.py
@@ -128,13 +128,14 @@ def safe_call(fn, *args, retries=2, delay=0.8, **kwargs):
 
 
 def tx_type_label(tt) -> str:
-       """
+    """
     Map a transaction type (int or bytes or None) to a short human-readable label.
     """
     mapping = {0: "Legacy", 1: "AccessList", 2: "EIP-1559"}
     if isinstance(tt, int):
         return mapping.get(tt, f"Unknown({tt})")
     return mapping.get(0, "Legacy")
+
 
 def summarize_tx(w3: Web3, tx_hash: str, block_cache: Dict[int, Any], latest_block: int) -> Dict[str, Any]:
     """


### PR DESCRIPTION
The function and docstring are mis-indented and could cause syntax issues.