### PR TITLE
Treat None tx type explicitly as Legacy

### DIFF
--- a/batch_fee_report.py
+++ b/batch_fee_report.py
@@ -132,9 +132,12 @@ def tx_type_label(tt) -> str:
     Map a transaction type (int or bytes or None) to a short human-readable label.
     """
     mapping = {0: "Legacy", 1: "AccessList", 2: "EIP-1559"}
-    if isinstance(tt, int):
+      if isinstance(tt, int):
         return mapping.get(tt, f"Unknown({tt})")
+    if tt is None:
+        return "Legacy"
     return mapping.get(0, "Legacy")
+
 
 def summarize_tx(w3: Web3, tx_hash: str, block_cache: Dict[int, Any], latest_block: int) -> Dict[str, Any]:
     """


### PR DESCRIPTION
Make the behavior for None explicit and readable