### PR TITLE
Fix indentation of parse_args() arguments

### DIFF
--- a/batch_fee_report.py
+++ b/batch_fee_report.py
@@ -250,7 +250,7 @@ def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         description="Batch analyze transaction fees and efficiency; outputs CSV or JSON."
     )
-   ap.add_argument("-r", "--rpc", default=DEFAULT_RPC, help="RPC URL (default from RPC_URL env)")
+    ap.add_argument("-r", "--rpc", default=DEFAULT_RPC, help="RPC URL (default from RPC_URL env)")
     ap.add_argument("-f", "--file", help="File with one tx hash per line (default: stdin)")
     ap.add_argument("-l", "--limit", type=int, help="Limit number of hashes read")
     ap.add_argument("-o", "--out", help="CSV output path (default: stdout)")


### PR DESCRIPTION
ap.add_argument for --rpc is mis-indented and will crash