### PR TITLE
Clamp avgBlockTimeSec to non-negative

### DIFF
--- a/fee-profile.py
+++ b/fee-profile.py
@@ -103,8 +103,9 @@ def analyze(w3: Web3, blocks: int, step: int, head_override: int | None = None) 
         first_block = w3.eth.get_block(head)
         last_block = w3.eth.get_block(start)
         import datetime; print(f"🕒 Latest block timestamp: {datetime.datetime.utcfromtimestamp(block.timestamp)} UTC")
-        time_diff = first_block.timestamp - last_block.timestamp
+                time_diff = first_block.timestamp - last_block.timestamp
         block_time_avg = time_diff / (head - start) if head > start else 0
+        block_time_avg = max(0, block_time_avg)
     else:
         block_time_avg = 0
 


### PR DESCRIPTION
Just a tiny safety if something weird happens with timestamp