### PR TITLE
Make “run started” and “using RPC” logs go to stderr

### DIFF
--- a/fee-profile.py
+++ b/fee-profile.py
@@ -198,8 +198,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-        print(f"📅 Fee-Profile run started at UTC: {time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())}")
-    print(f"⚙️ Using RPC endpoint: {args.rpc}")
+           print(
+        f"📅 Fee-Profile run started at UTC: "
+        f"{time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())}",
+        file=sys.stderr,
+    )
+    print(f"⚙️ Using RPC endpoint: {args.rpc}", file=sys.stderr)
         if args.blocks <= 0 or args.step <= 0:
         print("❌ --blocks and --step must be > 0", file=sys.stderr)
                 if args.blocks > 100_000:


### PR DESCRIPTION
CLI tools that have a --json mode, it’s nice if:

- stdout contains only the machine-readable data (JSON or human summary)
- stderr contains logs and progress (“starting…”, “using RPC…” etc.)